### PR TITLE
Add release publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Build and Attach Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Publish self-contained EXE
+        run: |
+          dotnet publish Benjis-Shop-Toolbox/Benjis-Shop-Toolbox.csproj \
+            -c Release -r win-x64 --self-contained \
+            -p:PublishSingleFile=true \
+            -o publish
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: publish/Benjis-Shop-Toolbox.exe


### PR DESCRIPTION
## Summary
- build a single-file self-contained release exe on tags
- allow manual workflow trigger
- attach the exe to the GitHub Release

## Testing
- `dotnet --version`
- `dotnet build Benjis-Shop-Toolbox.sln -c Release` *(fails: .NET 9.0 not supported in environment)*

------
https://chatgpt.com/codex/tasks/task_e_687f256b02bc83278553e9939c00f541