### PR TITLE
Implement log bundling option

### DIFF
--- a/Benjis-Shop-Toolbox/Components/Pages/Home.razor
+++ b/Benjis-Shop-Toolbox/Components/Pages/Home.razor
@@ -62,9 +62,9 @@
                 <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
             </div>
         }
-        @if (FilteredLogs.Any())
+        @if (DisplayLogs.Any())
         {
-            <MudTable Style="height: 85dvh" Height="95%" FixedFooter="true" FixedHeader="true" Items="FilteredLogs" Hover="true" OnRowClick="@((TableRowClickEventArgs<LogEntry> t) => ShowLogDetails(t))">
+            <MudTable Style="height: 85dvh" Height="95%" FixedFooter="true" FixedHeader="true" Items="DisplayLogs" Hover="true" OnRowClick="@((TableRowClickEventArgs<LogEntry> t) => ShowLogDetails(t))">
                 <HeaderContent>
                     <MudTh>Zeit</MudTh>
                     <MudTh>Ebene</MudTh>
@@ -75,7 +75,13 @@
                     <MudTd DataLabel="Ebene">
                         <MudChip T="string" Color="@GetColor(context.Level)" Icon="@GetIcon(context.Level)" Variant="Variant.Filled">@context.Level</MudChip>
                     </MudTd>
-                    <MudTd DataLabel="Nachricht">@Highlight(context.Message)</MudTd>
+                    <MudTd DataLabel="Nachricht">
+                        @Highlight(context.Message)
+                        @if (context.Count > 1)
+                        {
+                            <span class="ms-1">(x@context.Count)</span>
+                        }
+                    </MudTd>
                 </RowTemplate>
                 <PagerContent>
                     <MudTablePager PageSizeOptions="new int[] { 10, 25, 50, 100, int.MaxValue }"
@@ -195,6 +201,40 @@
         .Where(l => l.Time >= SelectedSince)
         .Where(l => string.IsNullOrWhiteSpace(_searchText)
             || l.Message.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<LogEntry> DisplayLogs => Settings.BundleLogs
+        ? BundleLogs(FilteredLogs)
+        : FilteredLogs;
+
+    private static IEnumerable<LogEntry> BundleLogs(IEnumerable<LogEntry> logs)
+    {
+        LogEntry? current = null;
+        foreach (var log in logs)
+        {
+            if (current != null && log.Message == current.Message && log.Level == current.Level)
+            {
+                current.Count += log.Count;
+            }
+            else
+            {
+                if (current != null)
+                {
+                    yield return current;
+                }
+                current = new LogEntry
+                {
+                    Time = log.Time,
+                    Level = log.Level,
+                    Message = log.Message,
+                    Count = log.Count
+                };
+            }
+        }
+        if (current != null)
+        {
+            yield return current;
+        }
+    }
 
     private MarkupString Highlight(string message)
     {

--- a/Benjis-Shop-Toolbox/Components/Pages/Settings.razor
+++ b/Benjis-Shop-Toolbox/Components/Pages/Settings.razor
@@ -27,6 +27,7 @@
     </MudSelect>
     <MudSwitch @bind-Value="Setting.LoadOnStartup" T="bool" Color="Color.Primary">Beim Starten der App die Logs laden</MudSwitch>
     <MudSwitch @bind-Value="Setting.OnlySinceRestart" T="bool" Color="Color.Primary">Nur Logs seit letztem Neustart</MudSwitch>
+    <MudSwitch @bind-Value="Setting.BundleLogs" T="bool" Color="Color.Primary">Gleiche Logs bündeln</MudSwitch>
     <MudSwitch @bind-Value="Setting.RestartShopOnThemeChange" T="bool" Color="Color.Primary">Bei Theme wechsel Shop neustarten</MudSwitch>
     <MudTextField @bind-Value="Setting.RepoPath" Label="Repo Pfad" Variant="Variant.Filled" Class="mb-2"
                   Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="ChooseRepo" />

--- a/Benjis-Shop-Toolbox/Models/ToolboxSettings.cs
+++ b/Benjis-Shop-Toolbox/Models/ToolboxSettings.cs
@@ -13,5 +13,10 @@ namespace Benjis_Shop_Toolbox.Models
         
         public string? ShopYamlPath { get; set; }
         public bool RestartShopOnThemeChange { get; set; }
+
+        /// <summary>
+        /// Gibt an, ob aufeinanderfolgende identische Logeinträge gebündelt angezeigt werden sollen.
+        /// </summary>
+        public bool BundleLogs { get; set; }
     }
 }

--- a/Benjis-Shop-Toolbox/Services/LogService.cs
+++ b/Benjis-Shop-Toolbox/Services/LogService.cs
@@ -7,6 +7,10 @@ namespace Benjis_Shop_Toolbox.Services
         public DateTime Time { get; set; }
         public LogLevel Level { get; set; }
         public string Message { get; set; } = string.Empty;
+        /// <summary>
+        /// Anzahl gebündelter Logeinträge.
+        /// </summary>
+        public int Count { get; set; } = 1;
     }
 
     public class LogService


### PR DESCRIPTION
## Summary
- group consecutive identical logs with BundleLogs setting
- show count of bundled logs in Home
- allow toggling log bundling in Settings
- extend `LogEntry` and settings model for bundling

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f554a52f8832796df722b9d2d772a