### PR TITLE
Add multiselect for log level filter

### DIFF
--- a/ElectronApp/Components/Pages/Home.razor
+++ b/ElectronApp/Components/Pages/Home.razor
@@ -57,8 +57,8 @@
                 <MudTextField Variant="Variant.Text" @bind-Value="_searchText" Immediate="true" Label="Suche" Class="w-100"/>
             </div>
             <div class="col-2">
-                <MudSelect T="LogLevel" Value="_selectedLevel" ValueChanged="@(async (LogLevel l) => await LoadLogs(l))" Label="Ebene">
-                    @foreach (var level in Enum.GetValues<LogLevel>())
+                <MudSelect T="LogLevel" MultiSelection="true" SelectedValues="_selectedLevels" SelectedValuesChanged="@(async levels => await SelectedLevelsChanged(levels))" Label="Ebene">
+                    @foreach (var level in Enum.GetValues<LogLevel>().Where(l => l != LogLevel.All))
                     {
                         <MudSelectItem Value="@level">@level.GetDescription()</MudSelectItem>
                     }
@@ -210,7 +210,9 @@
     // Log viewer fields
     private LogService _logService = default!;
     private IEnumerable<LogEntry> _logs = Enumerable.Empty<LogEntry>();
-    private LogLevel _selectedLevel = LogLevel.All;
+    private HashSet<LogLevel> _selectedLevels = Enum.GetValues<LogLevel>()
+        .Where(l => l != LogLevel.All)
+        .ToHashSet();
     private bool _autoRefresh;
     private int _refreshSeconds;
     private bool _onlySinceRestart;
@@ -227,6 +229,7 @@
 
     private IEnumerable<LogEntry> FilteredLogs => _logs
         .Where(l => l.Time >= SelectedSince)
+        .Where(l => _selectedLevels.Count == 0 || _selectedLevels.Contains(l.Level))
         .Where(l => string.IsNullOrWhiteSpace(_searchText)
             || l.Message.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
 
@@ -358,20 +361,15 @@
         _isLoading = true;
         StateHasChanged();
         var since = _onlySinceRestart ? _lastShopRestart : AppInfo.StartTime;
-        _logs = await Task.Run(() => _logService.GetLogs(since, _selectedLevel));
+        _logs = await Task.Run(() => _logService.GetLogs(since, LogLevel.All));
         _isLoading = false;
         StateHasChanged();
     }
 
-    private async Task LoadLogs(LogLevel logLevel)
+    private async Task SelectedLevelsChanged(IEnumerable<LogLevel> levels)
     {
-        _isLoading = true;
-        StateHasChanged();
-        var since = _onlySinceRestart ? _lastShopRestart : AppInfo.StartTime;
-        _selectedLevel = logLevel;
-        _logs = await Task.Run(() => _logService.GetLogs(since, logLevel));
-        _isLoading = false;
-        StateHasChanged();
+        _selectedLevels = levels.ToHashSet();
+        await LoadLogs();
     }
 
     private async Task LoadLogs(ReloadOption logLevel)
@@ -388,7 +386,7 @@
             _onlySinceRestart = true;
         }
         var since = logLevel == ReloadOption.AlleLogs ? DateTime.MinValue  : _onlySinceRestart ? _lastShopRestart : AppInfo.StartTime;
-        _logs = await Task.Run(() => _logService.GetLogs(since, _selectedLevel));
+        _logs = await Task.Run(() => _logService.GetLogs(since, LogLevel.All));
         _isLoading = false;
         StateHasChanged();
     }

--- a/ElectronApp/Components/Pages/Home.razor
+++ b/ElectronApp/Components/Pages/Home.razor
@@ -222,7 +222,8 @@
     private ServerManager manager = new ServerManager();
     private string _searchText = string.Empty;
     private bool _isLoading;
-
+    private ReloadOption reload;
+    
     private DateTime SelectedSince => _logOptions == ReloadOption.AlleLogs
         ? DateTime.MinValue
         : _onlySinceRestart ? _lastShopRestart : AppInfo.StartTime;
@@ -360,7 +361,7 @@
     {
         _isLoading = true;
         StateHasChanged();
-        var since = _onlySinceRestart ? _lastShopRestart : AppInfo.StartTime;
+        var since = reload == ReloadOption.AlleLogs ? DateTime.MinValue  : _onlySinceRestart ? _lastShopRestart : AppInfo.StartTime;
         _logs = await Task.Run(() => _logService.GetLogs(since, LogLevel.All));
         _isLoading = false;
         StateHasChanged();
@@ -374,6 +375,7 @@
 
     private async Task LoadLogs(ReloadOption logLevel)
     {
+        reload = logLevel;
         _isLoading = true;
         StateHasChanged();
         _logOptions = logLevel;

--- a/ElectronApp/electron.manifest.json
+++ b/ElectronApp/electron.manifest.json
@@ -1,20 +1,24 @@
 {
   "executable": "ElectronApp",
+  "aspCoreBackendPort": 8005,
   "splashscreen": {
     "imageFile": ""
   },
-  "name": "Benjis-Shop-Toolbox",
-  "author": "Benjamin Biber",
+  "name": "Benjis-Toolbox-Shop",
+  "author": "",
   "singleInstance": false,
-  "environment": "Production",
+  "environment": "Benjis-Toolbox-Shop",
   "build": {
-    "appId": "com.Benjis-Shop-Toolbox.app",
-    "productName": "Benjis-Shop-Toolbox",
+    "appId": "com.ElectronApp.app",
+    "productName": "Benjis-Toolbox-Shop",
     "copyright": "Copyright © 2020",
     "buildVersion": "1.0.0",
+    "win": {
+      "icon": "../../../bin/Release/net8.0/win-x64/wwwroot/favicon.ico"
+    },
     "compression": "maximum",
     "directories": {
-      "output": ".../.././bin/Desktop"
+      "output": "../../../bin/Desktop"
     },
     "extraResources": [
       {


### PR DESCRIPTION
## Summary
- allow selecting multiple log levels on the start page

## Testing
- `dotnet build ElectronApp/ElectronApp.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6881d5580a288327887ff4e3b7ab24d7