### PR TITLE
Add shop editing page and site shop settings

### DIFF
--- a/ElectronApp/Components/Layout/TopBar/TopBar.razor
+++ b/ElectronApp/Components/Layout/TopBar/TopBar.razor
@@ -2,6 +2,7 @@
     <MudNavMenu>
         <MudNavLink IconColor="Color.Primary" Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
         <MudNavLink IconColor="Color.Primary" Href="themes" Icon="@Icons.Material.Filled.Link">Themes</MudNavLink>
+        <MudNavLink IconColor="Color.Primary" Href="shop" Icon="@Icons.Material.Filled.Store">Shop</MudNavLink>
         <MudNavLink IconColor="Color.Primary" Href="sites" Icon="@Icons.Material.Filled.Dns">Seiten</MudNavLink>
         <MudNavLink IconColor="Color.Primary" Href="settings" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
     </MudNavMenu>

--- a/ElectronApp/Components/Pages/Shop.razor
+++ b/ElectronApp/Components/Pages/Shop.razor
@@ -1,0 +1,89 @@
+@page "/shop"
+@using Benjis_Shop_Toolbox.Models
+@using Benjis_Shop_Toolbox.Services
+@using ElectronNET.API.Entities
+@inject SettingsService SettingsService
+@inject ISnackbar Snackbar
+
+<MudPaper Class="pa-4" Elevation="4">
+    <MudText Typo="Typo.h5" Class="mb-4">Shop Einstellungen</MudText>
+    <MudSelect T="string" Value="_selectedSite" ValueChanged="OnSiteChanged" Label="Shop" Variant="Variant.Filled" Class="mb-4">
+        @foreach (var site in Settings.SiteSettings.Where(s => s.IsShop))
+        {
+            <MudSelectItem Value="@site.Name">@site.Name</MudSelectItem>
+        }
+    </MudSelect>
+
+    @if (_config != null)
+    {
+        <MudTextField @bind-Value="_config.ShopId" Label="ShopId" Variant="Variant.Filled" Class="mb-2" />
+        <MudTextField @bind-Value="_config.UserId" Label="UserId" Variant="Variant.Filled" Class="mb-2" />
+        <MudTextField @bind-Value="_config.BaseTheme" Label="BaseTheme" Variant="Variant.Filled" Class="mb-2" />
+        <MudTextField @bind-Value="_config.ThemeOverwrite" Label="ThemeOverwrite" Variant="Variant.Filled" Class="mb-2" />
+        <MudButton OnClick="Save" Color="Color.Primary" Variant="Variant.Filled" Class="mt-2">Speichern</MudButton>
+    }
+    else if (!string.IsNullOrEmpty(_selectedSite))
+    {
+        <MudAlert Severity="Severity.Info" Class="mt-2">shop.yaml nicht gefunden.</MudAlert>
+    }
+</MudPaper>
+
+@code {
+    private string? _selectedSite;
+    private ZionConfiguration? _config;
+    private ToolboxSettings Settings => SettingsService.Settings;
+
+    protected override void OnInitialized()
+    {
+        var firstShop = Settings.SiteSettings.FirstOrDefault(s => s.IsShop);
+        if (firstShop != null)
+        {
+            _selectedSite = firstShop.Name;
+            LoadConfig();
+        }
+    }
+
+    private void OnSiteChanged(string? name)
+    {
+        _selectedSite = name;
+        LoadConfig();
+    }
+
+    private void LoadConfig()
+    {
+        _config = null;
+        if (string.IsNullOrEmpty(_selectedSite))
+            return;
+        var info = Settings.SiteSettings.FirstOrDefault(s => s.Name == _selectedSite);
+        if (info != null && !string.IsNullOrEmpty(info.ShopYamlPath) && File.Exists(info.ShopYamlPath))
+        {
+            _config = ShopYamlLoader.LoadConfiguration(info.ShopYamlPath);
+        }
+    }
+
+    private void Save()
+    {
+        if (_config == null || string.IsNullOrEmpty(_selectedSite))
+            return;
+        var info = Settings.SiteSettings.FirstOrDefault(s => s.Name == _selectedSite);
+        if (info == null || string.IsNullOrEmpty(info.ShopYamlPath))
+        {
+            Snackbar.Add("Kein Pfad zur shop.yaml konfiguriert", Severity.Error);
+            return;
+        }
+        try
+        {
+            var serializer = new YamlDotNet.Serialization.SerializerBuilder()
+                .WithNamingConvention(YamlDotNet.Serialization.NamingConventions.CamelCaseNamingConvention.Instance)
+                .Build();
+            var root = new ZionRoot { ZionConfiguration = _config };
+            var yaml = serializer.Serialize(root);
+            File.WriteAllText(info.ShopYamlPath, yaml);
+            Snackbar.Add("shop.yaml gespeichert", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Fehler beim Speichern: {ex.Message}", Severity.Error);
+        }
+    }
+}

--- a/ElectronApp/Components/Pages/Sites.razor
+++ b/ElectronApp/Components/Pages/Sites.razor
@@ -5,7 +5,9 @@
 @inject SettingsService SettingsService
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject FileDialogService FileDialog
 @using ElectronApp.Components.Dialogs
+@using ElectronNET.API.Entities
 
 <MudPaper Class="pa-4" Elevation="4">
     <div class="d-flex justify-content-end mb-2">
@@ -31,12 +33,22 @@
                 <HeaderContent>
                     <MudTh>Name</MudTh>
                     <MudTh>Status</MudTh>
+                    <MudTh>Shop</MudTh>
+                    <MudTh>shop.yaml</MudTh>
                     <MudTh></MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Name">@context</MudTd>
                     <MudTd DataLabel="Status">
                         <MudChip T="string" Color="@GetStateColor(GetSiteState(context))" Variant="Variant.Filled">@GetSiteState(context)</MudChip>
+                    </MudTd>
+                    <MudTd>
+                        <MudCheckBox Value="GetSiteSetting(context).IsShop" ValueChanged="@((bool v) => ToggleShop(context, v))" />
+                    </MudTd>
+                    <MudTd>
+                        <MudTextField Value="GetSiteSetting(context).ShopYamlPath" ValueChanged="@((string v) => UpdateYamlPath(context, v))" Disabled="!GetSiteSetting(context).IsShop" Variant="Variant.Outlined"
+                                      Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+                                      OnAdornmentClick="@(() => ChooseYaml(context))" />
                     </MudTd>
                     <MudTd>
                         <MudIconButton Icon="@Icons.Material.Filled.Start" Color="Color.Success" OnClick="@(() => StartSite(context))" />
@@ -225,6 +237,46 @@
             Snackbar.Add($"Gruppe '{groupName}' nicht gefunden.", Severity.Warning);
         }
     }
-    
+
+    private SiteSetting GetSiteSetting(string name)
+    {
+        var setting = Settings.SiteSettings.FirstOrDefault(s => s.Name == name);
+        if (setting == null)
+        {
+            setting = new SiteSetting { Name = name };
+            Settings.SiteSettings.Add(setting);
+        }
+        return setting;
+    }
+
+    private void ToggleShop(string name, bool value)
+    {
+        var setting = GetSiteSetting(name);
+        setting.IsShop = value;
+        SettingsService.Save();
+    }
+
+    private void UpdateYamlPath(string name, string path)
+    {
+        var setting = GetSiteSetting(name);
+        setting.ShopYamlPath = path;
+        SettingsService.Save();
+    }
+
+    private void ChooseYaml(string name)
+    {
+        var filters = new FileFilter[]
+        {
+            new FileFilter { Name = "YAML", Extensions = new[] { "yaml", "yml" } }
+        };
+        var initialDir = Path.GetDirectoryName(GetSiteSetting(name).ShopYamlPath) ?? string.Empty;
+        var path = FileDialog.OpenFile("shop.yaml auswählen", filters, initialDir);
+        if (!string.IsNullOrEmpty(path))
+        {
+            UpdateYamlPath(name, path);
+            StateHasChanged();
+        }
+    }
+
     private ToolboxSettings Settings => SettingsService.Settings;
 }

--- a/ElectronApp/Models/SiteSetting.cs
+++ b/ElectronApp/Models/SiteSetting.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Benjis_Shop_Toolbox.Models
+{
+    /// <summary>
+    /// Stores additional configuration for an IIS site.
+    /// </summary>
+    public class SiteSetting
+    {
+        public string Name { get; set; } = string.Empty;
+        public bool IsShop { get; set; }
+        public string? ShopYamlPath { get; set; }
+    }
+}

--- a/ElectronApp/Models/ToolboxSettings.cs
+++ b/ElectronApp/Models/ToolboxSettings.cs
@@ -25,5 +25,10 @@ namespace Benjis_Shop_Toolbox.Models
         /// Optional grouping for IIS sites displayed on the Sites page.
         /// </summary>
         public List<SiteGroup> SiteGroups { get; set; } = new();
+
+        /// <summary>
+        /// Additional configuration per IIS site.
+        /// </summary>
+        public List<SiteSetting> SiteSettings { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- add navigation link for new shop page
- allow setting per-site shop flags and yaml path
- store site level config in settings
- implement new shop page to edit shop.yaml

## Testing
- `dotnet build ElectronApp/ElectronApp.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68872e54309c83279167553f320da2ca