### PR TITLE
Add restart delay setting

### DIFF
--- a/ElectronApp/Components/Pages/Home.razor
+++ b/ElectronApp/Components/Pages/Home.razor
@@ -147,7 +147,8 @@
 </div>
 
 @code {
-    private readonly TimeSpan RestartDelay = TimeSpan.FromSeconds(3);
+    private TimeSpan RestartDelay =>
+        TimeSpan.FromSeconds(Math.Max(1, Settings.RestartDelaySeconds));
 
     private void StartIisApp()
     {

--- a/ElectronApp/Components/Pages/Settings.razor
+++ b/ElectronApp/Components/Pages/Settings.razor
@@ -31,6 +31,7 @@
     <MudSwitch @bind-Value="Setting.OnlySinceRestart" T="bool" Color="Color.Primary">Nur Logs seit letztem Neustart</MudSwitch>
     <MudSwitch @bind-Value="Setting.BundleLogs" T="bool" Color="Color.Primary">Gleiche Logs bündeln</MudSwitch>
     <MudSwitch @bind-Value="Setting.RestartShopOnThemeChange" T="bool" Color="Color.Primary">Bei Theme wechsel Shop neustarten</MudSwitch>
+    <MudNumericField T="int" @bind-Value="Setting.RestartDelaySeconds" Label="Neustart-Wartezeit (Sekunden)" Variant="Variant.Filled" Class="mb-2" Min="1" />
     <MudTextField @bind-Value="Setting.RepoPath" Label="Repo Pfad" Variant="Variant.Filled" Class="mb-2"
                   Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="ChooseRepo" />
     <MudTextField @bind-Value="Setting.ShopThemesPath" Label="Shop Themes Pfad" Variant="Variant.Filled" Class="mb-2"
@@ -54,6 +55,10 @@
         if (Setting.AutoRefreshSeconds <= 0)
         {
             Setting.AutoRefreshEnabled = false;
+        }
+        if (Setting.RestartDelaySeconds < 1)
+        {
+            Setting.RestartDelaySeconds = 1;
         }
         var success = SettingsService.Save();
         if (success)

--- a/ElectronApp/Components/Pages/Sites.razor
+++ b/ElectronApp/Components/Pages/Sites.razor
@@ -62,7 +62,8 @@
 </MudPaper>
 
 @code {
-    private readonly TimeSpan RestartDelay = TimeSpan.FromSeconds(3);
+    private TimeSpan RestartDelay =>
+        TimeSpan.FromSeconds(Math.Max(1, Settings.RestartDelaySeconds));
     private ServerManager _manager = new();
 
     private Dictionary<string, List<string>> GroupedSites { get; set; } = new();

--- a/ElectronApp/Components/Pages/Themes.razor
+++ b/ElectronApp/Components/Pages/Themes.razor
@@ -139,7 +139,8 @@
         }
     }
     
-    private readonly TimeSpan RestartDelay = TimeSpan.FromSeconds(3);
+    private TimeSpan RestartDelay =>
+        TimeSpan.FromSeconds(Math.Max(1, Settings.RestartDelaySeconds));
     
     private void StartIisApp()
     {

--- a/ElectronApp/Models/ToolboxSettings.cs
+++ b/ElectronApp/Models/ToolboxSettings.cs
@@ -17,6 +17,12 @@ namespace Benjis_Shop_Toolbox.Models
         public bool RestartShopOnThemeChange { get; set; }
 
         /// <summary>
+        /// Delay in seconds between stopping and starting a site when restarting.
+        /// Must be at least one second.
+        /// </summary>
+        public int RestartDelaySeconds { get; set; } = 3;
+
+        /// <summary>
         /// Gibt an, ob aufeinanderfolgende identische Logeinträge gebündelt angezeigt werden sollen.
         /// </summary>
         public bool BundleLogs { get; set; }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 - Log filtering
 - Favicon ändern
 - Responsive
+- Einstellbare Wartezeit beim Neustart von Sites


### PR DESCRIPTION
## Summary
- add RestartDelaySeconds setting to `ToolboxSettings`
- add input for restart delay in Settings page with minimum 1 second
- use the configured restart delay on Home, Sites, and Themes pages
- document restart delay setting in README

## Testing
- `dotnet build ElectronApp/ElectronApp.csproj -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_6888c32e975883278a04a6cd5af67b00