### PR TITLE
Add per-shop path configuration

### DIFF
--- a/ElectronApp/Components/Dialogs/CloneThemeDialog.razor
+++ b/ElectronApp/Components/Dialogs/CloneThemeDialog.razor
@@ -13,7 +13,7 @@
                 <MudCheckBox @bind-Value="_linkAfterClone" Color="Color.Primary" Label="Als Symlink hinzufügen und in shop.yaml eintragen" />
             </div>
             <div class="col">
-                <MudCheckBox @bind-Value="_linkAfterClone" Color="Color.Primary" Label="Nach dem Klonen in Rider öffnen" />
+                <MudCheckBox @bind-Value="_openInRider" Color="Color.Primary" Label="Nach dem Klonen in Rider öffnen" />
             </div>
         </div>
     </DialogContent>
@@ -25,6 +25,8 @@
 
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public string ShopYamlPath { get; set; } = string.Empty;
+    [Parameter] public string ShopThemesPath { get; set; } = string.Empty;
     private string _gitUrl = string.Empty;
     private bool _linkAfterClone;
     private bool _openInRider;
@@ -38,14 +40,14 @@
             {
                 var repoName = Path.GetFileNameWithoutExtension(_gitUrl.TrimEnd('/')
                     .Split('/').Last());
-                ThemeService.LinkAndOverwrite(repoName);
+                ThemeService.LinkAndOverwrite(repoName, ShopThemesPath, ShopYamlPath);
             }
 
             if (success && _openInRider)
             {
                 var repoName = Path.GetFileNameWithoutExtension(_gitUrl.TrimEnd('/')
                     .Split('/').Last());
-                var theme = ThemeService.GetThemeByName(repoName);
+                var theme = ThemeService.GetThemeByName(repoName, ShopThemesPath, ShopYamlPath);
                 SolutionOpener.OpenSolutionInRider(theme.ThemeFolder);
             }
 

--- a/ElectronApp/Components/Dialogs/SitePathsDialog.razor
+++ b/ElectronApp/Components/Dialogs/SitePathsDialog.razor
@@ -1,0 +1,70 @@
+@using Benjis_Shop_Toolbox.Services
+@using ElectronNET.API.Entities
+
+<MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-4">Shop Pfade bearbeiten</MudText>
+        <MudTextField @bind-Value="_yamlPath" Label="shop.yaml" Variant="Variant.Filled" Class="mb-2"
+                      Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="ChooseYaml" />
+        <MudTextField @bind-Value="_themePath" Label="Themes Ordner" Variant="Variant.Filled" Class="mb-2"
+                      Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="ChooseTheme" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary" OnClick="Save">Speichern</MudButton>
+        <MudButton Color="Color.Default" OnClick="Cancel">Abbrechen</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public string SiteName { get; set; } = string.Empty;
+
+    [Inject] SettingsService SettingsService { get; set; } = default!;
+    [Inject] FileDialogService FileDialog { get; set; } = default!;
+
+    private string _yamlPath = string.Empty;
+    private string _themePath = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        var setting = SettingsService.Settings.SiteSettings.FirstOrDefault(s => s.Name == SiteName);
+        if (setting != null)
+        {
+            _yamlPath = setting.ShopYamlPath ?? string.Empty;
+            _themePath = setting.ShopThemesPath ?? string.Empty;
+        }
+    }
+
+    private void ChooseYaml()
+    {
+        var filters = new FileFilter[] { new FileFilter { Name = "YAML", Extensions = new[] { "yaml", "yml" } } };
+        var path = FileDialog.OpenFile("shop.yaml auswählen", filters, Path.GetDirectoryName(_yamlPath) ?? string.Empty);
+        if (!string.IsNullOrEmpty(path))
+        {
+            _yamlPath = path;
+        }
+    }
+
+    private void ChooseTheme()
+    {
+        var path = FileDialog.OpenFolder("Themes Ordner auswählen", _themePath);
+        if (!string.IsNullOrEmpty(path))
+        {
+            _themePath = path;
+        }
+    }
+
+    private void Save()
+    {
+        var setting = SettingsService.Settings.SiteSettings.FirstOrDefault(s => s.Name == SiteName);
+        if (setting != null)
+        {
+            setting.ShopYamlPath = _yamlPath;
+            setting.ShopThemesPath = _themePath;
+            SettingsService.Save();
+        }
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+
+    void Cancel() => MudDialog.Cancel();
+}

--- a/ElectronApp/Components/Pages/Sites.razor
+++ b/ElectronApp/Components/Pages/Sites.razor
@@ -281,7 +281,12 @@
     private async Task OpenPathsDialog(string name)
     {
         var parameters = new DialogParameters { ["SiteName"] = name };
-        var dlg = DialogService.Show<SitePathsDialog>("Shop Pfade", parameters);
+        var options = new DialogOptions()
+        {
+            FullScreen = true,
+            MaxWidth = MaxWidth.Medium
+        };
+        var dlg = DialogService.Show<SitePathsDialog>("Shop Pfade", parameters,options);
         var result = await dlg.Result;
         if (!result.Canceled)
         {

--- a/ElectronApp/Components/Pages/Sites.razor
+++ b/ElectronApp/Components/Pages/Sites.razor
@@ -35,6 +35,7 @@
                     <MudTh>Status</MudTh>
                     <MudTh>Shop</MudTh>
                     <MudTh>shop.yaml</MudTh>
+                    <MudTh>Themes</MudTh>
                     <MudTh></MudTh>
                 </HeaderContent>
                 <RowTemplate>
@@ -45,12 +46,10 @@
                     <MudTd>
                         <MudCheckBox Value="GetSiteSetting(context).IsShop" ValueChanged="@((bool v) => ToggleShop(context, v))" />
                     </MudTd>
+                    <MudTd DataLabel="shop.yaml">@GetSiteSetting(context).ShopYamlPath</MudTd>
+                    <MudTd DataLabel="Themes">@GetSiteSetting(context).ShopThemesPath</MudTd>
                     <MudTd>
-                        <MudTextField Value="GetSiteSetting(context).ShopYamlPath" ValueChanged="@((string v) => UpdateYamlPath(context, v))" Disabled="!GetSiteSetting(context).IsShop" Variant="Variant.Outlined"
-                                      Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen"
-                                      OnAdornmentClick="@(() => ChooseYaml(context))" />
-                    </MudTd>
-                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Disabled="!GetSiteSetting(context).IsShop" OnClick="@(() => OpenPathsDialog(context))" />
                         <MudIconButton Icon="@Icons.Material.Filled.Start" Color="Color.Success" OnClick="@(() => StartSite(context))" />
                         <MudIconButton Icon="@Icons.Material.Filled.RestartAlt" Color="Color.Warning" OnClick="@(() => RestartSite(context))" />
                         <MudIconButton Icon="@Icons.Material.Filled.Stop" Color="Color.Error" OnClick="@(() => StopSite(context))" />
@@ -275,6 +274,17 @@
         if (!string.IsNullOrEmpty(path))
         {
             UpdateYamlPath(name, path);
+            StateHasChanged();
+        }
+    }
+
+    private async Task OpenPathsDialog(string name)
+    {
+        var parameters = new DialogParameters { ["SiteName"] = name };
+        var dlg = DialogService.Show<SitePathsDialog>("Shop Pfade", parameters);
+        var result = await dlg.Result;
+        if (!result.Canceled)
+        {
             StateHasChanged();
         }
     }

--- a/ElectronApp/Components/Pages/Themes.razor
+++ b/ElectronApp/Components/Pages/Themes.razor
@@ -37,7 +37,6 @@
                 <HeaderContent>
                     <MudTh>Name</MudTh>
                     <MudTh>Pfad</MudTh>
-                    <MudTh>Shop</MudTh>
                     <MudTh>Link</MudTh>
                     <MudTh></MudTh>
                     <MudTh>Wird im Shop verwendet</MudTh>
@@ -45,7 +44,6 @@
                 <RowTemplate>
                     <MudTd DataLabel="Name">@context.Name</MudTd>
                     <MudTd DataLabel="Pfad">@context.Path</MudTd>
-                    <MudTd DataLabel="Shop">@_selectedSite</MudTd>
                     <MudTd DataLabel="Link">@(context.LinkExists ? "Ja" : "Nein")</MudTd>
                     <MudTd>
                         @if (context.LinkExists)

--- a/ElectronApp/Components/Pages/Themes.razor
+++ b/ElectronApp/Components/Pages/Themes.razor
@@ -16,6 +16,12 @@
         <MudText Typo="Typo.h5">Themes</MudText>
         <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary" OnClick="OpenCloneDialog" />
     </div>
+    <MudSelect T="string" Value="_selectedSite" ValueChanged="OnSiteChanged" Label="Shop" Variant="Variant.Filled" Class="mb-4">
+        @foreach (var site in Settings.SiteSettings.Where(s => s.IsShop))
+        {
+            <MudSelectItem Value="@site.Name">@site.Name</MudSelectItem>
+        }
+    </MudSelect>
     @if (_isLoading)
     {
         <div class="d-flex justify-content-center my-3">
@@ -31,6 +37,7 @@
                 <HeaderContent>
                     <MudTh>Name</MudTh>
                     <MudTh>Pfad</MudTh>
+                    <MudTh>Shop</MudTh>
                     <MudTh>Link</MudTh>
                     <MudTh></MudTh>
                     <MudTh>Wird im Shop verwendet</MudTh>
@@ -38,6 +45,7 @@
                 <RowTemplate>
                     <MudTd DataLabel="Name">@context.Name</MudTd>
                     <MudTd DataLabel="Pfad">@context.Path</MudTd>
+                    <MudTd DataLabel="Shop">@_selectedSite</MudTd>
                     <MudTd DataLabel="Link">@(context.LinkExists ? "Ja" : "Nein")</MudTd>
                     <MudTd>
                         @if (context.LinkExists)
@@ -67,10 +75,23 @@
 @code {
     private IEnumerable<IGrouping<string, ThemeInfo>>? _groupedThemes;
     private bool _isLoading;
+    private string? _selectedSite;
     private ToolboxSettings Settings => SettingsService.Settings;
+    private SiteSetting? SelectedSetting => Settings.SiteSettings.FirstOrDefault(s => s.Name == _selectedSite);
+
+    private async Task OnSiteChanged(string? name)
+    {
+        _selectedSite = name;
+        await LoadAsync();
+    }
 
     protected override async Task OnInitializedAsync()
     {
+        var first = Settings.SiteSettings.FirstOrDefault(s => s.IsShop);
+        if (first != null)
+        {
+            _selectedSite = first.Name;
+        }
         await LoadAsync();
     }
 
@@ -96,7 +117,15 @@
     {
         _isLoading = true;
         StateHasChanged();
-        _groupedThemes = await Task.Run(() => ThemeService.GetThemes()
+        var setting = SelectedSetting;
+        if (setting == null)
+        {
+            _groupedThemes = null;
+            _isLoading = false;
+            StateHasChanged();
+            return;
+        }
+        _groupedThemes = await Task.Run(() => ThemeService.GetThemes(setting.ShopThemesPath ?? string.Empty, setting.ShopYamlPath ?? string.Empty)
             .GroupBy(t => t.Repo)
             .OrderBy(g => g.Key)
             .ToList());
@@ -106,7 +135,13 @@
 
     private void Load()
     {
-        _groupedThemes = ThemeService.GetThemes()
+        var setting = SelectedSetting;
+        if (setting == null)
+        {
+            _groupedThemes = null;
+            return;
+        }
+        _groupedThemes = ThemeService.GetThemes(setting.ShopThemesPath ?? string.Empty, setting.ShopYamlPath ?? string.Empty)
             .GroupBy(t => t.Repo)
             .OrderBy(g => g.Key)
             .ToList();
@@ -118,7 +153,9 @@
         StateHasChanged();
         try
         {
-            var result = ThemeService.SetThemeOverwrite(info);
+            var setting = SelectedSetting;
+            if (setting == null) return;
+            var result = ThemeService.SetThemeOverwrite(setting.ShopYamlPath ?? string.Empty, info);
             if (result)
             {
                 await LoadAsync();
@@ -211,19 +248,30 @@
     
     private async Task Create(ThemeInfo info)
     {
-        ThemeService.CreateLink(info);
+        var setting = SelectedSetting;
+        if (setting == null) return;
+        ThemeService.CreateLink(setting.ShopThemesPath ?? string.Empty, info);
         await LoadAsync();
     }
 
     private async Task Remove(ThemeInfo info)
     {
-        ThemeService.RemoveLink(info);
+        var setting = SelectedSetting;
+        if (setting == null) return;
+        ThemeService.RemoveLink(setting.ShopThemesPath ?? string.Empty, info);
         await LoadAsync();
     }
 
     private async Task OpenCloneDialog()
     {
-        var dlg = DialogService.Show<CloneThemeDialog>("Repo klonen");
+        var parameters = new DialogParameters();
+        var setting = SelectedSetting;
+        if (setting != null)
+        {
+            parameters.Add("ShopYamlPath", setting.ShopYamlPath ?? string.Empty);
+            parameters.Add("ShopThemesPath", setting.ShopThemesPath ?? string.Empty);
+        }
+        var dlg = DialogService.Show<CloneThemeDialog>("Repo klonen", parameters);
         var result = await dlg.Result;
         if (!result.Canceled)
         {

--- a/ElectronApp/Models/SiteSetting.cs
+++ b/ElectronApp/Models/SiteSetting.cs
@@ -10,5 +10,9 @@ namespace Benjis_Shop_Toolbox.Models
         public string Name { get; set; } = string.Empty;
         public bool IsShop { get; set; }
         public string? ShopYamlPath { get; set; }
+        /// <summary>
+        /// Optional path to the themes folder of this shop.
+        /// </summary>
+        public string? ShopThemesPath { get; set; }
     }
 }

--- a/ElectronApp/Services/ThemeLinkService.cs
+++ b/ElectronApp/Services/ThemeLinkService.cs
@@ -16,18 +16,18 @@ namespace Benjis_Shop_Toolbox.Services
             _notifications = notifications;
         }
 
-        public IEnumerable<ThemeInfo> GetThemes()
+        public IEnumerable<ThemeInfo> GetThemes(string shopThemesPath, string shopYamlPath)
         {
             try
             {
-                if (string.IsNullOrEmpty(_settings.Settings.ShopYamlPath))
+                if (string.IsNullOrEmpty(shopYamlPath))
                 {
                     return new List<ThemeInfo>();
                 }
 
-                var config = ShopYamlLoader.LoadConfiguration(_settings.Settings.ShopYamlPath);
+                var config = ShopYamlLoader.LoadConfiguration(shopYamlPath);
                 var repo = _settings.Settings.RepoPath;
-                var shop = _settings.Settings.ShopThemesPath;
+                var shop = shopThemesPath;
                 var themes = new List<ThemeInfo>();
                 if (Directory.Exists(repo))
                 {
@@ -53,15 +53,15 @@ namespace Benjis_Shop_Toolbox.Services
             }
         }
 
-        public ThemeInfo GetThemeByName(string repoName)
+        public ThemeInfo GetThemeByName(string repoName, string shopThemesPath, string shopYamlPath)
         {
-            var themes = GetThemes();
+            var themes = GetThemes(shopThemesPath, shopYamlPath);
             return themes.FirstOrDefault(x => x.Name.ToLower() == repoName.ToLower()) ?? new ThemeInfo();
         }
         
-        public bool SetThemeOverwrite(ThemeInfo theme)
+        public bool SetThemeOverwrite(string shopYamlPath, ThemeInfo theme)
         {
-            if (string.IsNullOrEmpty(_settings.Settings.ShopYamlPath))
+            if (string.IsNullOrEmpty(shopYamlPath))
             {
                 _notifications.Error("Kein Pfad zur shop.yaml konfiguriert.");
                 return false;
@@ -69,9 +69,9 @@ namespace Benjis_Shop_Toolbox.Services
 
             try
             {
-                var config = ShopYamlLoader.LoadConfiguration(_settings.Settings.ShopYamlPath);
+                var config = ShopYamlLoader.LoadConfiguration(shopYamlPath);
                 config.ThemeOverwrite = theme.Name;
-                ShopYamlLoader.UpdateConfig(_settings.Settings.ShopYamlPath, theme.Name);
+                ShopYamlLoader.UpdateConfig(shopYamlPath, theme.Name);
                 _notifications.Success($"Theme wurde auf {theme.Name} gesetzt.");
                 return true;
             }
@@ -82,11 +82,11 @@ namespace Benjis_Shop_Toolbox.Services
             }
         }
         
-        public bool CreateLink(ThemeInfo theme)
+        public bool CreateLink(string shopThemesPath, ThemeInfo theme)
         {
             try
             {
-                var linkPath = Path.Combine(_settings.Settings.ShopThemesPath, theme.Name);
+                var linkPath = Path.Combine(shopThemesPath, theme.Name);
                 if (!Directory.Exists(linkPath) && !File.Exists(linkPath))
                 {
                     Directory.CreateSymbolicLink(linkPath, theme.Path);
@@ -101,11 +101,11 @@ namespace Benjis_Shop_Toolbox.Services
             }
         }
 
-        public bool RemoveLink(ThemeInfo theme)
+        public bool RemoveLink(string shopThemesPath, ThemeInfo theme)
         {
             try
             {
-                var linkPath = Path.Combine(_settings.Settings.ShopThemesPath, theme.Name);
+                var linkPath = Path.Combine(shopThemesPath, theme.Name);
                 if (File.Exists(linkPath))
                 {
                     File.Delete(linkPath);
@@ -125,21 +125,21 @@ namespace Benjis_Shop_Toolbox.Services
             }
         }
 
-        public bool LinkAndOverwrite(string repoName)
+        public bool LinkAndOverwrite(string repoName, string shopThemesPath, string shopYamlPath)
         {
             try
             {
-                var themes = GetThemes().Where(t => t.Repo == repoName).ToList();
+                var themes = GetThemes(shopThemesPath, shopYamlPath).Where(t => t.Repo == repoName).ToList();
                 foreach (var theme in themes)
                 {
                     if (!theme.LinkExists)
                     {
-                        CreateLink(theme);
+                        CreateLink(shopThemesPath, theme);
                     }
                 }
                 if (themes.Count > 0)
                 {
-                    SetThemeOverwrite(themes[0]);
+                    SetThemeOverwrite(shopYamlPath, themes[0]);
                 }
                 return true;
             }


### PR DESCRIPTION
## Summary
- support theme folder configuration per shop
- implement SitePathsDialog for editing shop paths
- display and edit shop/theme paths on Sites page
- allow selecting shop in Themes page and pass settings to clone dialog
- adjust ThemeLinkService to work with per-shop paths

## Testing
- `dotnet build Benjis-Shop-Toolbox.sln`

------
https://chatgpt.com/codex/tasks/task_e_6888cad136808327ae83b44ce4d31567