### PR TITLE
Add message polling and notification badge

### DIFF
--- a/ElectronApp/Components/Dialogs/SettingsDialog.razor
+++ b/ElectronApp/Components/Dialogs/SettingsDialog.razor
@@ -4,6 +4,7 @@
 @using Benjis_Shop_Toolbox.Services
 @using Microsoft.Web.Administration
 @inject SettingsService SettingsService
+@inject MessageCheckerService MessageChecker
 @inject ISnackbar Snackbar
 @inject FileDialogService FileDialog
 <MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
@@ -22,6 +23,12 @@
         <MudTextField @bind-Value="Setting.ShopYamlPath" Label="Pfad zur shop.yaml" Variant="Variant.Filled" Class="mb-2"
                       Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="ChooseYaml" />
         <MudSelect T="int" @bind-Value="Setting.AutoRefreshSeconds" Label="Auto Refresh (Sekunden)" Class="mb-2">
+            @foreach (var reloadTime in ReloadTime.ReloadTimes)
+            {
+                <MudSelectItem Value="@(Int32.Parse(reloadTime.Value.TotalSeconds.ToString()))">@reloadTime.Key</MudSelectItem>
+            }
+        </MudSelect>
+        <MudSelect T="int" @bind-Value="Setting.MessageCheckSeconds" Label="Nachrichten prüfen (Sekunden)" Class="mb-2">
             @foreach (var reloadTime in ReloadTime.ReloadTimes)
             {
                 <MudSelectItem Value="@(Int32.Parse(reloadTime.Value.TotalSeconds.ToString()))">@reloadTime.Key</MudSelectItem>
@@ -62,6 +69,7 @@
         if (success)
         {
             Snackbar.Add("Einstellungen gespeichert", Severity.Success);
+            MessageChecker.UpdateInterval();
         }
         else
         {

--- a/ElectronApp/Components/Layout/TopBar/TopBar.razor
+++ b/ElectronApp/Components/Layout/TopBar/TopBar.razor
@@ -1,10 +1,15 @@
+@inject MessageCheckerService MessageChecker
+@implements IDisposable
+
 <MudDrawer @bind-Open="IsOpen" Variant="DrawerVariant.Responsive" ClipMode="DrawerClipMode.Docked" Anchor="Anchor.Start" Elevation="3">
     <MudNavMenu>
         <MudNavLink IconColor="Color.Primary" Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
         <MudNavLink IconColor="Color.Primary" Href="themes" Icon="@Icons.Material.Filled.Link">Themes</MudNavLink>
         <MudNavLink IconColor="Color.Primary" Href="shop" Icon="@Icons.Material.Filled.Store">Shop</MudNavLink>
         <MudNavLink IconColor="Color.Primary" Href="sites" Icon="@Icons.Material.Filled.Dns">Seiten</MudNavLink>
-        <MudNavLink IconColor="Color.Primary" Href="My4Sellers" Icon="@Icons.Material.Filled.Message">My4Sellers</MudNavLink>
+        <MudBadge Dot="@MessageChecker.HasNewMessages" Color="Color.Error">
+            <MudNavLink IconColor="Color.Primary" Href="My4Sellers" Icon="@Icons.Material.Filled.Message">My4Sellers</MudNavLink>
+        </MudBadge>
         <MudNavLink IconColor="Color.Primary" Href="settings" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
     </MudNavMenu>
 </MudDrawer>
@@ -20,4 +25,14 @@
 
 @code {
     public bool IsOpen { get; set; } = true;
+
+    protected override void OnInitialized()
+    {
+        MessageChecker.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        MessageChecker.OnChange -= StateHasChanged;
+    }
 }

--- a/ElectronApp/Components/Pages/My4Sellers.razor
+++ b/ElectronApp/Components/Pages/My4Sellers.razor
@@ -1,14 +1,16 @@
-﻿@page "/My4Sellers"
+@page "/My4Sellers"
 @using ElectronApp.Models
 @using Microsoft.AspNetCore.Html
-@using Newtonsoft.Json
+@inject MessageCheckerService MessageChecker
+@implements IDisposable
+
 <h3>My4Sellers</h3>
 
-@if(result1 != null && result1.Any())
+@if (MessageChecker.Messages.Any())
 {
-    @foreach (var ding in result1)
+    foreach (var ding in MessageChecker.Messages)
     {
-        @foreach (var item in ding.content)
+        foreach (var item in ding.content)
         {
             @((MarkupString)item)
         }
@@ -16,29 +18,15 @@
 }
 
 @code {
-    private List<DataItem> result1;
-    
     protected override async Task OnInitializedAsync()
     {
-        string url = "https://automation.benjaminbiber.de/webhook/c8500a7e-2e2d-4fdd-9d52-271eb2f15038"; // <--- Ersetze mit deiner echten URL
-
-        using (HttpClient client = new HttpClient())
-        {
-            try
-            {
-                // JSON von URL abrufen
-                HttpResponseMessage response = await client.GetAsync(url);
-                response.EnsureSuccessStatusCode();
-                string responseBody = await response.Content.ReadAsStringAsync();
-
-                // In C#-Modell deserialisieren
-                result1 = JsonConvert.DeserializeObject<List<DataItem>>(responseBody);
-            }
-            catch (HttpRequestException e)
-            {
-                Console.WriteLine($"Fehler beim HTTP-Request: {e.Message}");
-            }
-        }
+        MessageChecker.OnChange += StateHasChanged;
+        await MessageChecker.CheckNowAsync();
+        MessageChecker.MarkAsRead();
     }
 
+    public void Dispose()
+    {
+        MessageChecker.OnChange -= StateHasChanged;
+    }
 }

--- a/ElectronApp/Components/Pages/Settings.razor
+++ b/ElectronApp/Components/Pages/Settings.razor
@@ -4,6 +4,7 @@
 @using ElectronNET.API.Entities
 @using Microsoft.Web.Administration
 @inject SettingsService SettingsService
+@inject MessageCheckerService MessageChecker
 @inject ISnackbar Snackbar
 @inject FileDialogService FileDialog
 
@@ -22,6 +23,12 @@
     <MudTextField @bind-Value="Setting.ShopYamlPath" Label="Pfad zur shop.yaml" Variant="Variant.Filled" Class="mb-2"
                   Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="ChooseYaml" />
     <MudSelect T="int" @bind-Value="Setting.AutoRefreshSeconds" Label="Auto Refresh (Sekunden)" Class="mb-2">
+        @foreach (var reloadTime in ReloadTime.ReloadTimes)
+        {
+            <MudSelectItem Value="@(Int32.Parse(reloadTime.Value.TotalSeconds.ToString()))">@reloadTime.Key</MudSelectItem>
+        }
+    </MudSelect>
+    <MudSelect T="int" @bind-Value="Setting.MessageCheckSeconds" Label="Nachrichten prüfen (Sekunden)" Class="mb-2">
         @foreach (var reloadTime in ReloadTime.ReloadTimes)
         {
             <MudSelectItem Value="@(Int32.Parse(reloadTime.Value.TotalSeconds.ToString()))">@reloadTime.Key</MudSelectItem>
@@ -64,6 +71,7 @@
         if (success)
         {
             Snackbar.Add("Einstellungen gespeichert", Severity.Success);
+            MessageChecker.UpdateInterval();
         }
         else
         {

--- a/ElectronApp/Components/_Imports.razor
+++ b/ElectronApp/Components/_Imports.razor
@@ -9,3 +9,4 @@
 @using ElectronApp
 @using ElectronApp.Components
 @using MudBlazor
+@using Benjis_Shop_Toolbox.Services

--- a/ElectronApp/Models/ToolboxSettings.cs
+++ b/ElectronApp/Models/ToolboxSettings.cs
@@ -8,6 +8,7 @@ namespace Benjis_Shop_Toolbox.Models
         public string? LogName { get; set; } = "4SELLERS";
         public int AutoRefreshSeconds { get; set; }
         public bool AutoRefreshEnabled { get; set; }
+        public int MessageCheckSeconds { get; set; } = 60;
         public bool LoadOnStartup { get; set; }
         public bool OnlySinceRestart { get; set; }
         public string RepoPath { get; set; }

--- a/ElectronApp/Program.cs
+++ b/ElectronApp/Program.cs
@@ -17,6 +17,7 @@ builder.Logging.AddConsole();
 
 builder.Services.AddMudServices();
 builder.Services.AddSingleton<SettingsService>();
+builder.Services.AddSingleton<MessageCheckerService>();
 builder.Services.AddScoped<NotificationService>();
 builder.Services.AddScoped<SolutionOpener>();
 builder.Services.AddScoped<FileDialogService>();

--- a/ElectronApp/Services/MessageCheckerService.cs
+++ b/ElectronApp/Services/MessageCheckerService.cs
@@ -1,0 +1,87 @@
+using System.Timers;
+using ElectronApp.Models;
+using Newtonsoft.Json;
+
+namespace Benjis_Shop_Toolbox.Services;
+
+public class MessageCheckerService : IAsyncDisposable
+{
+    private readonly SettingsService _settingsService;
+    private readonly HttpClient _client = new();
+    private System.Timers.Timer? _timer;
+
+    private List<DataItem> _messages = new();
+    public IReadOnlyList<DataItem> Messages => _messages;
+
+    public bool HasNewMessages { get; private set; }
+
+    public event Action? OnChange;
+
+    private const string WorkflowUrl = "https://automation.benjaminbiber.de/webhook/c8500a7e-2e2d-4fdd-9d52-271eb2f15038";
+
+    public MessageCheckerService(SettingsService settingsService)
+    {
+        _settingsService = settingsService;
+        StartTimer();
+    }
+
+    public async Task CheckNowAsync()
+    {
+        await FetchMessagesAsync();
+    }
+
+    private void StartTimer()
+    {
+        _timer?.Dispose();
+        var seconds = _settingsService.Settings.MessageCheckSeconds;
+        if (seconds > 0)
+        {
+            _timer = new System.Timers.Timer(seconds * 1000);
+            _timer.Elapsed += async (_, _) => await FetchMessagesAsync();
+            _timer.AutoReset = true;
+            _timer.Start();
+        }
+    }
+
+    private async Task FetchMessagesAsync()
+    {
+        try
+        {
+            var response = await _client.GetAsync(WorkflowUrl);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            var items = JsonConvert.DeserializeObject<List<DataItem>>(json);
+            if (items != null)
+            {
+                bool changed = _messages.Count != items.Count || !_messages.SelectMany(m => m.content).SequenceEqual(items.SelectMany(m => m.content));
+                _messages = items;
+                if (changed)
+                {
+                    HasNewMessages = true;
+                    NotifyStateChanged();
+                }
+            }
+        }
+        catch
+        {
+            // ignore errors
+        }
+    }
+
+    public void MarkAsRead()
+    {
+        HasNewMessages = false;
+        NotifyStateChanged();
+    }
+
+    public void UpdateInterval() => StartTimer();
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+
+    public ValueTask DisposeAsync()
+    {
+        _timer?.Dispose();
+        _client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add `MessageCheckerService` for async message polling
- show a notification badge in the navigation when new messages arrive
- integrate message polling interval setting
- update settings pages to configure polling interval

## Testing
- `dotnet build ElectronApp/ElectronApp.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_688b649804648327b6b7e37b49a0feac